### PR TITLE
Add auto publish to Chrome Web Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .sass-cache
 package
 app/scripts
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: node_js
+node_js:
+  - 4
+deploy:
+  - provider: script
+    script: npm run release
+    on:
+      branch: master
+      tags: true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "pr-file-filter-for-Github",
   "private": true,
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=4.0.0"
+  },
+  "scripts": {
+    "build": "gulp",
+    "release": "npm run build && webstore upload --source dist/ --auto-publish"
   },
   "devDependencies": {
     "babel-core": "^6.7.2",
@@ -11,6 +15,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.1",
+    "chrome-webstore-upload-cli": "^1.0.3",
     "del": "^2.2.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",


### PR DESCRIPTION
With this PR a git tag push will automatically build and upload a new version of the extension to the Chrome Web Store. 

### Todo
- [ ] Fix build step. `npm run build` is failing with `Error: ENOENT: no such file or directory`
- [ ] Add following travis environment variables `CLIENT_ID `, `CLIENT_SECRET `, `REFRESH_TOKEN` and `EXTENSION_ID`